### PR TITLE
mate 1.18

### DIFF
--- a/mate-extra/atril/Pkgfile
+++ b/mate-extra/atril/Pkgfile
@@ -1,15 +1,16 @@
-# Description: Simply a document viewer
+# Description: Simply a pdf document viewer.
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: caja dconf djvulibre gtk2 libsecret libspectre mate-desktop mate-icon-theme poppler-glib poppler
 
 name=atril
-version=1.14.1
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {
 cd $name-$version
+sed -i 's|/usr/share/javascript/mathjax|/usr/share/mathjax|' backend/epub/epub-document.c
 ./configure \
         --prefix=/usr \
         --libexecdir=/usr/lib/${name} \
@@ -22,8 +23,7 @@ cd $name-$version
         --enable-pixbuf \
         --enable-comics \
         --enable-xps \
-        --enable-introspection \
-        --disable-static
+        --enable-introspection 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/atril/Pkgfile
+++ b/mate-extra/atril/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Simply a pdf document viewer.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: caja dconf djvulibre gtk2 libsecret libspectre mate-desktop mate-icon-theme poppler-glib poppler
+# Depends on: caja dconf djvulibre gtk3 libsecret libspectre mate-desktop mate-icon-theme poppler-glib poppler
 
 name=atril
 version=1.18.0
@@ -14,7 +14,7 @@ sed -i 's|/usr/share/javascript/mathjax|/usr/share/mathjax|' backend/epub/epub-d
 ./configure \
         --prefix=/usr \
         --libexecdir=/usr/lib/${name} \
-        --with-gtk=2.0 \
+        --with-gtk=3.0 \
         --enable-gtk-doc \
         --enable-djvu \
         --enable-dvi \

--- a/mate-extra/atril/atril.post-install
+++ b/mate-extra/atril/atril.post-install
@@ -1,3 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
-    update-desktop-database -q

--- a/mate-extra/caja-extensions/Pkgfile
+++ b/mate-extra/caja-extensions/Pkgfile
@@ -1,20 +1,17 @@
-# Description: Caja extensions (common files)
+# Description: Caja extensions (common files).
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: caja gupnp
 
-
 name=caja-extensions
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/${name}-$version.tar.xz)
 
 build() {
 cd ${name}-$version
  ./configure \
-        --prefix=/usr \
-        --with-gtk=2.0
+        --prefix=/usr 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/engrampa/Pkgfile
+++ b/mate-extra/engrampa/Pkgfile
@@ -1,21 +1,19 @@
-# Description: Archive manipulator for MATE (GTK2 version)
+# Description: Archive manipulator for MATE (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: caja json-glib
 
 name=engrampa
-version=1.14.1
+version=1.18.1
 release=1
-source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
+source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz fr-rpm-bsdtar.patch)
 
 build() {
 cd $name-$version
+patch -Np1 -i ${SRC}/fr-rpm-bsdtar.patch
 ./configure \
         --prefix=/usr \
         --libexecdir=/usr/lib/${name} \
-        --with-gtk=2.0 \
-        --disable-static \
         --disable-packagekit
 make
 make DESTDIR=$PKG install

--- a/mate-extra/engrampa/engrampa.post-install
+++ b/mate-extra/engrampa/engrampa.post-install
@@ -1,3 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
-    update-desktop-database -q

--- a/mate-extra/engrampa/fr-rpm-bsdtar.patch
+++ b/mate-extra/engrampa/fr-rpm-bsdtar.patch
@@ -1,0 +1,60 @@
+This makes Engrampa use bsdtar to extract .RPM packages instead of using cpio.
+It is useful on systems that do not have cpio or RPM/YUM
+This patch was created for Arch Linux, however should work on any system that has bsdtar capable of handling cpio archives.
+
+------------------+
+ rpm2cpio.c       |   2 +-
+ fr-command-rpm.c |   8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+Index: src/commands/rpm2cpio.c
+================================
+--- mate-file-archiver-1.6.0/src/commands/rpm2cpio.c 2013-03-31
++++ mate-file-archiver-1.6.0/src/commands/rpm2cpio.c	2013-07-26
+@@ -128,7 +128,7 @@
+ 		archive_command = "bzip2 -dc";
+ 	fclose (stream);
+ 
+-	command = g_strdup_printf ("sh -c \"dd if=%s ibs=%u skip=1 2>/dev/null | %s | cpio %s\"", g_shell_quote (filename), offset, archive_command, cpio_args->str);
++	command = g_strdup_printf ("sh -c \"dd if=%s ibs=%u skip=1 2>/dev/null | %s | bsdtar %s\"", g_shell_quote (filename), offset, archive_command, cpio_args->str);
+ 
+ 	return system (command);
+ }
+Index: src/fr-command-rpm.c
+================================
+--- mate-file-archiver-1.6.0/src/fr-command-rpm.c	2013-03-31
++++ mate-file-archiver-1.6.0/src/fr-command-rpm.c	2013-07-26
+@@ -175,7 +175,7 @@
+ 
+ 	fr_process_begin_command (comm->process, "sh");
+ 	fr_process_add_arg (comm->process, "-c");
+-	fr_process_add_arg_concat (comm->process, PRIVEXECDIR "rpm2cpio ", comm->e_filename, " -itv", NULL);
++	fr_process_add_arg_concat (comm->process, PRIVEXECDIR "rpm2cpio ", comm->e_filename, " -tvf -", NULL);
+ 	fr_process_end_command (comm->process);
+ 	fr_process_start (comm->process);
+ }
+@@ -200,7 +200,7 @@
+ 
+ 	cmd = g_string_new (PRIVEXECDIR "rpm2cpio ");
+ 	g_string_append (cmd, comm->e_filename);
+-	g_string_append (cmd, " -idu ");
++	g_string_append (cmd, " -xf - ");
+ 	for (scan = file_list; scan; scan = scan->next) {
+ 		char *filename = g_shell_quote (scan->data);
+ 		g_string_append (cmd, filename);
+@@ -233,7 +233,7 @@
+ 	FrCommandCap capabilities;
+ 
+ 	capabilities = FR_COMMAND_CAN_ARCHIVE_MANY_FILES;
+-	if (is_program_available ("cpio", check_command))
++	if (is_program_available ("bsdtar", check_command))
+ 		capabilities |= FR_COMMAND_CAN_READ;
+ 
+ 	return capabilities;
+@@ -244,7 +244,7 @@
+ fr_command_rpm_get_packages (FrCommand  *comm,
+ 			     const char *mime_type)
+ {
+-	return PACKAGES ("cpio,rpm");
++	return PACKAGES ("bsdtar,rpm");
+ }

--- a/mate-extra/eom/Pkgfile
+++ b/mate-extra/eom/Pkgfile
@@ -1,7 +1,7 @@
 # Description: An image viewing and cataloging program for MATE (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: exempi gtk2 gtk-update-icon-cache libexif mate-desktop mate-icon-theme python-gobject2 python-gtk
+# Depends on: exempi gtk2 gtk-update-icon-cache libexif mate-desktop mate-icon-theme python2-gobject2 python2-gtk 
 
 name=eom
 version=1.18.1

--- a/mate-extra/eom/Pkgfile
+++ b/mate-extra/eom/Pkgfile
@@ -1,7 +1,7 @@
 # Description: An image viewing and cataloging program for MATE (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: exempi gtk2 gtk-update-icon-cache libexif mate-desktop mate-icon-theme python2-gobject2 python2-gtk libpeas
+# Depends on: exempi gtk3 gtk-update-icon-cache libexif mate-desktop mate-icon-theme python2-gobject2 python2-gtk libpeas
 
 name=eom
 version=1.18.1

--- a/mate-extra/eom/Pkgfile
+++ b/mate-extra/eom/Pkgfile
@@ -1,11 +1,10 @@
-# Description: An image viewing and cataloging program for MATE (GTK2 version)
+# Description: An image viewing and cataloging program for MATE (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: exempi gtk2 gtk-update-icon-cache libexif mate-desktop mate-icon-theme python-gobject2 python-gtk 
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: exempi gtk2 gtk-update-icon-cache libexif mate-desktop mate-icon-theme python-gobject2 python-gtk
 
 name=eom
-version=1.14.1
+version=1.18.1
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -14,7 +13,6 @@ cd $name-$version
  ./configure \
         --prefix=/usr \
         --localstatedir=/var \
-        --with-gtk=2.0 \
         --with-librsvg \
         --enable-python
 make

--- a/mate-extra/eom/Pkgfile
+++ b/mate-extra/eom/Pkgfile
@@ -1,7 +1,7 @@
 # Description: An image viewing and cataloging program for MATE (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: exempi gtk2 gtk-update-icon-cache libexif mate-desktop mate-icon-theme python2-gobject2 python2-gtk 
+# Depends on: exempi gtk2 gtk-update-icon-cache libexif mate-desktop mate-icon-theme python2-gobject2 python2-gtk libpeas
 
 name=eom
 version=1.18.1

--- a/mate-extra/eom/eom.post-install
+++ b/mate-extra/eom/eom.post-install
@@ -1,3 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
-  update-desktop-database -q

--- a/mate-extra/libpeas/Pkgfile
+++ b/mate-extra/libpeas/Pkgfile
@@ -1,0 +1,16 @@
+# Description: A GObject-based plugins engine.
+# URL: https://wiki.gnome.org/Projects/Libpeas
+# Packager: fanch at nutyx dot org
+# Depends on: gdb, gtk3, gjs, vala, gobject-introspection, python-gobject2, python3-gobject, lua, valgrind
+
+name=libpeas
+version=1.20.0
+release=1
+source=(http://ftp.gnome.org/pub/gnome/sources/$name/${version%.*}/$name-$version.tar.xz)
+
+build() {
+cd $name-$version
+   ./configure --prefix=/usr 
+make
+make DESTDIR=$PKG install
+}

--- a/mate-extra/libpeas/libpeas.post-install
+++ b/mate-extra/libpeas/libpeas.post-install
@@ -1,0 +1,2 @@
+gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+

--- a/mate-extra/mate-applets/Pkgfile
+++ b/mate-extra/mate-applets/Pkgfile
@@ -5,6 +5,7 @@
 
 name=mate-applets
 version=1.18.1
+release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {

--- a/mate-extra/mate-applets/Pkgfile
+++ b/mate-extra/mate-applets/Pkgfile
@@ -1,25 +1,21 @@
-# Description: Applets for MATE panel
+# Description: Applets for MATE panel.
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: gtksourceview2 libgtop libnotify mate-panel mate-icon-theme python-gobject upower wireless-tools upower
 
 name=mate-applets
-version=1.14.0
-release=1
+version=1.18.1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {
 cd $name-$version
+sed -i 's/env python/env python2/' invest-applet/invest/{chart.py,invest-applet.py,mate-invest-chart}
  ./configure \
         --prefix=/usr \
         --sysconfdir=/etc \
         --libexecdir=/usr/lib/${name} \
-        --with-cpufreq-lib=cpupower \
         --enable-polkit \
-        --enable-ipv6 \
-        --enable-upower \
-        --with-gtk=2.0 \
-        --disable-static
+        --enable-ipv6 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/mate-applets/Pkgfile
+++ b/mate-extra/mate-applets/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Applets for MATE panel.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtksourceview2 libgtop libnotify mate-panel mate-icon-theme python-gobject upower wireless-tools upower
+# Depends on: gtksourceview3 libgtop libnotify mate-panel mate-icon-theme python-gobject upower wireless-tools upower 
 
 name=mate-applets
 version=1.18.1

--- a/mate-extra/mate-applets/mate-applets.post-install
+++ b/mate-extra/mate-applets/mate-applets.post-install
@@ -1,2 +1,0 @@
-/usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas > /dev/null 2>&1
-gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor

--- a/mate-extra/mate-calc/Pkgfile
+++ b/mate-extra/mate-calc/Pkgfile
@@ -5,6 +5,7 @@
 
 name=mate-calc
 version=1.18.0
+release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {

--- a/mate-extra/mate-calc/Pkgfile
+++ b/mate-extra/mate-calc/Pkgfile
@@ -1,20 +1,16 @@
-# Description: Common MATE utilities for viewing disk usage.
+# Description: Mate calculator.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 mate-panel libgtop
+# Depends on: gtk3
 
-name=mate-utils
-version=1.18.1
-release=1
+name=mate-calc
+version=1.18.0
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {
 cd $name-$version
 ./configure \
-        --prefix=/usr \
-        --libexecdir=/usr/lib/${name} \
-        --sysconfdir=/etc \
-        --disable-maintainer-flags
+        --prefix=/usr 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/mate-icon-theme-faenza/Pkgfile
+++ b/mate-extra/mate-icon-theme-faenza/Pkgfile
@@ -1,11 +1,10 @@
-# Description: Faenza icon theme for MATE
+# Description: Faenza icon theme for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: mate-common gtk-update-icon-cache
 
 name=mate-icon-theme-faenza
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -14,5 +13,4 @@ cd $name-$version
 ./autogen.sh --prefix=/usr 
 make
 make DESTDIR=$PKG install
-rm -f  $PKG/usr/share/icons/matefaenza/icon-theme.cache
 }

--- a/mate-extra/mate-icon-theme-faenza/mate-icon-theme-faenza.post-install
+++ b/mate-extra/mate-icon-theme-faenza/mate-icon-theme-faenza.post-install
@@ -1,3 +1,0 @@
-gtk-update-icon-cache -q -t -f /usr/share/icons/matefaenza
-gtk-update-icon-cache -q -t -f /usr/share/icons/matefaenzadark
-gtk-update-icon-cache -q -t -f /usr/share/icons/matefaenzagray

--- a/mate-extra/mate-indicator-applet/Pkgfile
+++ b/mate-extra/mate-indicator-applet/Pkgfile
@@ -1,17 +1,16 @@
-# Description: Applet MATE
+# Description: Applet MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: gtk2 mate-libindicator mate-panel
 
 name=mate-indicator-applet
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 build() {
 cd $name-$version
 ./configure --prefix=/usr \
-        --libexec=/usr/lib/${name} \
-        --disable-static
+        --libexec=/usr/lib/${name} 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/mate-indicator-applet/Pkgfile
+++ b/mate-extra/mate-indicator-applet/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Applet MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 mate-libindicator mate-panel
+# Depends on: gtk3 mate-libindicator mate-panel
 
 name=mate-indicator-applet
 version=1.18.0

--- a/mate-extra/mate-libindicator/Pkgfile
+++ b/mate-extra/mate-libindicator/Pkgfile
@@ -1,6 +1,5 @@
 # Description: A set of symbols and convience functions that all indicators would like to use. 
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
 # Packager: fanchyannmaria at orange dot fr
 # Depends on: gtk2
 

--- a/mate-extra/mate-libindicator/Pkgfile
+++ b/mate-extra/mate-libindicator/Pkgfile
@@ -1,11 +1,11 @@
 # Description: A set of symbols and convience functions that all indicators would like to use. 
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr
-# Depends on: gtk2
+# Depends on: gtk3
 
 name=mate-libindicator
 version=12.10.1
-release=1
+release=2
 source=(http://launchpad.net/libindicator/${version%.*}/$version/+download/libindicator-$version.tar.gz)
 
 build() {
@@ -14,16 +14,17 @@ sed 's/LIBINDICATOR_LIBS+="$LIBM"/LIBINDICATOR_LIBS+=" $LIBM"/g' -i libindicator
 sed 's/LIBM="-lmw"/LIBM=" -lmw"/g' -i libindicator-${version}/configure
 sed 's/LIBM="-lm"/LIBM=" -lm"/g' -i libindicator-${version}/configure
 sed 's/LIBS="-lm  $LIBS"/LIBS=" -lm  $LIBS"/g' -i libindicator-${version}/configure
-sed 's/LIBS="-lmw  $LIBS"/LIBS=" -lmw  $LIBS"/g' -i libindicator-${version}/configure
-mkdir -p build-gtk2
-cd build-gtk2
-			 ../libindicator-${version}/configure \
-			   --prefix=/usr \
-              --sysconfdir=/etc \
-			  --localstatedir=/var \
-			  --libexecdir=/usr/lib/$name \
-              --disable-static \
-              --with-gtk=2
+sed 's/LIBS="-lmw $LIBS"/LIBS=" -lmw $LIBS"/g' -i libindicator-${version}/configure
+mkdir -p build-gtk3
+cd build-gtk3
+../libindicator-${version}/configure \
+      --prefix=/usr \
+      --localstatedir=/var \
+      --libexecdir=/usr/lib/libindicator \
+      --sysconfdir=/etc \
+      --with-gtk=3 \
+      --disable-static \
+      --disable-tests
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/mate-netbook/Pkgfile
+++ b/mate-extra/mate-netbook/Pkgfile
@@ -1,11 +1,10 @@
-# Description: A simple window management tool (GTK2 version) 
+# Description: A simple window management tool (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: gtk2 libwnck libfakekey libunique1 mate-panel
 
 name=mate-netbook
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -14,9 +13,7 @@ cd $name-$version
 ./configure \
         --prefix=/usr \
         --libexec=/usr/lib/${name} \
-        --sysconfdir=/etc \
-        --with-gtk=2.0 \
-        --disable-static
+        --sysconfdir=/etc 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/mate-netbook/Pkgfile
+++ b/mate-extra/mate-netbook/Pkgfile
@@ -1,7 +1,7 @@
 # Description: A simple window management tool (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 libwnck libfakekey libunique1 mate-panel
+# Depends on: gtk3 libwnck3 libfakekey libunique1 mate-panel
 
 name=mate-netbook
 version=1.18.0

--- a/mate-extra/mate-netbook/mate-netbook.post-install
+++ b/mate-extra/mate-netbook/mate-netbook.post-install
@@ -1,1 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/

--- a/mate-extra/mate-sensors-applet/Pkgfile
+++ b/mate-extra/mate-sensors-applet/Pkgfile
@@ -1,7 +1,7 @@
 # Description: A MATE Panel applet to display readings from hardware sensors.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 libatasmart libnotify lm-sensors mate-panel
+# Depends on: gtk3 libatasmart libnotify lm-sensors mate-panel
 
 name=mate-sensors-applet
 version=1.18.1

--- a/mate-extra/mate-sensors-applet/Pkgfile
+++ b/mate-extra/mate-sensors-applet/Pkgfile
@@ -1,11 +1,10 @@
 # Description: A MATE Panel applet to display readings from hardware sensors.
-# URL: http://mate-desktop.org
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: gtk2 libatasmat libnotify lm-sensors mate-panel
+# URL: http://matsusoft.com.ar/projects/mate
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: gtk2 libatasmart libnotify lm-sensors mate-panel
 
 name=mate-sensors-applet
-version=1.14.0
+version=1.18.1
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -13,9 +12,7 @@ build() {
 cd $name-$version
 ./configure \
         --prefix=/usr \
-        --libexecdir=/usr/lib/${name} \
-        --with-gtk=2.0 \
-        --disable-static
+        --libexecdir=/usr/lib/${name} 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/mate-sensors-applet/mate-sensors-applet.post-install
+++ b/mate-extra/mate-sensors-applet/mate-sensors-applet.post-install
@@ -1,2 +1,0 @@
-usr/bin/glib-compile-schemas usr/share/glib-2.0/schemas > /dev/null 2>&1
-gtk-update-icon-cache -q -t -f usr/share/icons/hicolor

--- a/mate-extra/mate-terminal/Pkgfile
+++ b/mate-extra/mate-terminal/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Terminal MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 mate-desktop  vte
+# Depends on: gtk2 mate-desktop  vte3
 
 name=mate-terminal
 version=1.18.0

--- a/mate-extra/mate-terminal/Pkgfile
+++ b/mate-extra/mate-terminal/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Terminal MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 mate-desktop  vte3
+# Depends on: gtk3 mate-desktop  vte3
 
 name=mate-terminal
 version=1.18.0

--- a/mate-extra/mate-terminal/Pkgfile
+++ b/mate-extra/mate-terminal/Pkgfile
@@ -4,7 +4,7 @@
 # Depends on: gtk2 mate-desktop  vte
 
 name=mate-terminal
-version=1.18
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 

--- a/mate-extra/mate-terminal/Pkgfile
+++ b/mate-extra/mate-terminal/Pkgfile
@@ -1,20 +1,17 @@
-# Description:  Terminal MATE
+# Description: Terminal MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: gtk2 mate-desktop  vte
 
 name=mate-terminal
-version=1.14.0
+version=1.18
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {
 cd $name-$version
 ./configure \
-        --prefix=/usr \
-        --with-gtk=2.0 \
-        --disable-static
+        --prefix=/usr 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/mate-terminal/mate-terminal.post-install
+++ b/mate-extra/mate-terminal/mate-terminal.post-install
@@ -1,1 +1,0 @@
-glib-compile-schemas usr/share/glib-2.0/schemas/

--- a/mate-extra/mate-user-guide/Pkgfile
+++ b/mate-extra/mate-user-guide/Pkgfile
@@ -1,21 +1,17 @@
-# Description:  Mate user guide
-# URL: http://mate.desktop.org
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Description: Mate user guide.
+# URL: http://matsusoft.com.ar/projects/mate
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: itstool, intltool
 
-
 name=mate-user-guide
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {
 cd $name-$version
 ./configure \
-        --prefix=/usr \
-        --with-gtk=2.0 \
-        --disable-static
+        --prefix=/usr 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/mate-user-share/Pkgfile
+++ b/mate-extra/mate-user-share/Pkgfile
@@ -1,7 +1,7 @@
 # Description: User level public file sharing via WebDAV for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: apache bluez caja dconf gdk-pixbuf gtk2 libnotify libcanberra libunique1 mod-dnssd
+# Depends on: apache bluez caja dconf gdk-pixbuf gtk3 libnotify libcanberra libunique1 mod-dnssd
 
 name=mate-user-share
 version=1.18.0

--- a/mate-extra/mate-user-share/Pkgfile
+++ b/mate-extra/mate-user-share/Pkgfile
@@ -1,12 +1,10 @@
-# Description:  User level public file sharing via WebDAV for MATE
-# URL: http://mate.desktop.org
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Description: User level public file sharing via WebDAV for MATE.
+# URL: http://matsusoft.com.ar/projects/mate
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: apache bluez caja dconf gdk-pixbuf gtk2 libnotify libcanberra libunique1 mod-dnssd
 
-
 name=mate-user-share
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -16,10 +14,7 @@ cd $name-$version
         --prefix=/usr \
         --libexec=/usr/lib/${name} \
         --sysconfdir=/etc \
-        --disable-static \
-        --disable-scrollkeeper \
         --disable-bluetooth
 make
 make DESTDIR=$PKG install
-rm -f ${PKG}/usr/share/mate-user-share/dav_user_2.0.conf
 }

--- a/mate-extra/mate-user-share/mate-user-share.post-install
+++ b/mate-extra/mate-user-share/mate-user-share.post-install
@@ -1,3 +1,0 @@
- glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
-    update-desktop-database -q

--- a/mate-extra/mate-utils/Pkgfile
+++ b/mate-extra/mate-utils/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Common MATE utilities for viewing disk usage.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 mate-panel libgtop
+# Depends on: gtk3 mate-panel libgtop
 
 name=mate-utils
 version=1.18.1

--- a/mate-extra/mate-utils/mate-utils.post-install
+++ b/mate-extra/mate-utils/mate-utils.post-install
@@ -1,2 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/mate

--- a/mate-extra/mozo/Pkgfile
+++ b/mate-extra/mozo/Pkgfile
@@ -1,12 +1,11 @@
-# Description:  MATE menu editing tool
+# Description: MATE menu editing tool.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: mate-menus python-gobject gtk-update-icon-cache
-run=(gtk-update-icon-cache)
+# Runs on :python-gobject gtk-update-icon-cache
 
 name=mozo
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 

--- a/mate-extra/mozo/Pkgfile
+++ b/mate-extra/mozo/Pkgfile
@@ -2,7 +2,7 @@
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: mate-menus python-gobject gtk-update-icon-cache
-# Runs on :python-gobject gtk-update-icon-cache
+# Runs on : python-gobject gtk-update-icon-cache
 
 name=mozo
 version=1.18.0

--- a/mate-extra/mozo/mozo.post-install
+++ b/mate-extra/mozo/mozo.post-install
@@ -1,1 +1,0 @@
-gtk-update-icon-cache -q -t -f usr/share/icons/hicolor

--- a/mate-extra/pluma/Pkgfile
+++ b/mate-extra/pluma/Pkgfile
@@ -1,10 +1,10 @@
 # Description: A powerful text editor for MATE
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: enchant gtk2 libsoup iso-codes gtksourceview2 mate-desktop python-gobject2 python-gtk python-gtksourceview2
 
 name=pluma
-version=1.14.0
+version=1.18.1
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 

--- a/mate-extra/pluma/Pkgfile
+++ b/mate-extra/pluma/Pkgfile
@@ -1,7 +1,7 @@
 # Description: A powerful text editor for MATE
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: enchant gtk2 libsoup iso-codes gtksourceview3 mate-desktop python2-gobject2 python2-gtk python2-gtksourceview2 libpeas
+# Depends on: enchant gtk3 libsoup iso-codes gtksourceview3 mate-desktop python2-gobject2 python2-gtk python2-gtksourceview2 libpeas
 
 name=pluma
 version=1.18.1
@@ -13,7 +13,7 @@ cd $name-$version
 ./configure \
         --prefix=/usr \
         --libexecdir=/usr/lib/${name} \
-        --with-gtk=2.0 \
+        --with-gtk=3.0 \
         --enable-gtk-doc=no \
         --enable-python
 make

--- a/mate-extra/pluma/Pkgfile
+++ b/mate-extra/pluma/Pkgfile
@@ -1,7 +1,7 @@
 # Description: A powerful text editor for MATE
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: enchant gtk2 libsoup iso-codes gtksourceview2 mate-desktop python2-gobject2 python2-gtk python2-gtksourceview2
+# Depends on: enchant gtk2 libsoup iso-codes gtksourceview3 mate-desktop python2-gobject2 python2-gtk python2-gtksourceview2 libpeas
 
 name=pluma
 version=1.18.1

--- a/mate-extra/pluma/Pkgfile
+++ b/mate-extra/pluma/Pkgfile
@@ -1,7 +1,7 @@
 # Description: A powerful text editor for MATE
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: enchant gtk2 libsoup iso-codes gtksourceview2 mate-desktop python-gobject2 python-gtk python-gtksourceview2
+# Depends on: enchant gtk2 libsoup iso-codes gtksourceview2 mate-desktop python2-gobject2 python2-gtk python2-gtksourceview2
 
 name=pluma
 version=1.18.1

--- a/mate-extra/pluma/pluma.post-install
+++ b/mate-extra/pluma/pluma.post-install
@@ -1,2 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    update-desktop-database -q

--- a/mate-extra/python-caja/Pkgfile
+++ b/mate-extra/python-caja/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Python for Caja.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: caja python-gobject2
+# Depends on: caja python2-gobject2
 
 name=python-caja
 version=1.18.0

--- a/mate-extra/python-caja/Pkgfile
+++ b/mate-extra/python-caja/Pkgfile
@@ -1,19 +1,17 @@
-# Description: Python for Caja
+# Description: Python for Caja.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: caja python-gobject2
 
 name=python-caja
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {
 cd $name-$version
 ./configure \
-        --prefix=/usr \
-        --disable-static
+        --prefix=/usr 
 make
 make DESTDIR=$PKG install
 }

--- a/mate-extra/python-caja/Pkgfile
+++ b/mate-extra/python-caja/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Python for Caja.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: caja python2-gobject2
+# Depends on: caja python2-gobject python-gobject
 
 name=python-caja
 version=1.18.0

--- a/mate/caja/Pkgfile
+++ b/mate/caja/Pkgfile
@@ -1,11 +1,11 @@
 # Description: File manager for the MATE desktop (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: exempi mate-desktop pango gtk2 libexif libxml2 libunique1 desktop-file-utils libnotify
-# Run on: desktop-file-utils
+# Depends on: exempi mate-desktop pango gtk3 libexif libxml2 libunique1 desktop-file-utils libnotify
+
 
 name=caja
-version=1.18.1
+version=1.18.2
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -14,7 +14,7 @@ cd $name-$version
 ./configure \
         --prefix=/usr \
         --libexecdir=/usr/lib/${name} \
-        --with-gtk=2.0 \
+        --with-gtk=3.0 \
         --enable-unique \
         --enable-introspection \
         --disable-static \

--- a/mate/caja/Pkgfile
+++ b/mate/caja/Pkgfile
@@ -1,12 +1,11 @@
-# Description: File manager for the MATE desktop (GTK2 version)
+# Description: File manager for the MATE desktop (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: exempi mate-desktop pango gtk2 libexif libxml2 libunique1 desktop-file-utils
-run=(desktop-file-utils)
+# Run on: desktop-file-utils
 
 name=caja
-version=1.14.1
+version=1.18.1
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 

--- a/mate/caja/Pkgfile
+++ b/mate/caja/Pkgfile
@@ -1,7 +1,7 @@
 # Description: File manager for the MATE desktop (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: exempi mate-desktop pango gtk2 libexif libxml2 libunique1 desktop-file-utils
+# Depends on: exempi mate-desktop pango gtk2 libexif libxml2 libunique1 desktop-file-utils libnotify
 # Run on: desktop-file-utils
 
 name=caja

--- a/mate/caja/caja.post-install
+++ b/mate/caja/caja.post-install
@@ -1,4 +1,0 @@
-glib-compile-schemas usr/share/glib-2.0/schemas/
-update-mime-database usr/share/mime/ > /dev/null
-gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
-update-desktop-database -q

--- a/mate/marco/Pkgfile
+++ b/mate/marco/Pkgfile
@@ -1,7 +1,7 @@
-# Description: A window manager for MATE (GTK2 version).
+# Description: A window manager for MATE (GTK3 version).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: mate-desktop gtk2 libcanberra libgtop startup-notification zenity
+# Depends on: mate-desktop gtk3 libcanberra libgtop startup-notification zenity
 
 
 name=marco
@@ -15,7 +15,7 @@ cd $name-$version
         --prefix=/usr \
         --sysconfdir=/etc \
         --localstatedir=/var \
-        --with-gtk=2.0 \
+        --with-gtk=3.0 \
         --enable-startup-notification \
         --disable-static
 make

--- a/mate/marco/Pkgfile
+++ b/mate/marco/Pkgfile
@@ -1,11 +1,11 @@
-# Description:A window manager for MATE (GTK2 version)
+# Description: A window manager for MATE (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: mate-desktop gtk2 libcanberra libgtop startup-notification zenity
 
+
 name=marco
-version=1.14.2
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 

--- a/mate/marco/marco.post-install
+++ b/mate/marco/marco.post-install
@@ -1,1 +1,0 @@
-glib-compile-schemas usr/share/glib-2.0/schemas/

--- a/mate/mate-backgrounds/Pkgfile
+++ b/mate/mate-backgrounds/Pkgfile
@@ -1,11 +1,10 @@
-# Description: Background images and data for MATE
+# Description: Background images and data for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: intltool
 
 name=mate-backgrounds
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 

--- a/mate/mate-common/Pkgfile
+++ b/mate/mate-common/Pkgfile
@@ -1,10 +1,9 @@
-# Description: Common development macros for MATE
+# Description: Common development macros for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 
 name=mate-common
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/${name}-${version}.tar.xz)
 

--- a/mate/mate-control-center/Pkgfile
+++ b/mate/mate-control-center/Pkgfile
@@ -1,7 +1,7 @@
 # Description: The Control Center for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: murrine caja dconf desktop-file-utils gsettings-desktop-schemas gtk2 libgtop librsvg libunique1 xorg-libxscrnsaver xorg-libxt mate-desktop mate-icon-theme mate-libkbd mate-menus marco mate-settings-daemon
+# Depends on: murrine caja dconf desktop-file-utils gsettings-desktop-schemas gtk3 libgtop librsvg libunique1 xorg-libxscrnsaver xorg-libxt mate-desktop mate-icon-theme mate-libkbd mate-menus marco mate-settings-daemon
 
 name=mate-control-center
 version=1.18.1

--- a/mate/mate-control-center/Pkgfile
+++ b/mate/mate-control-center/Pkgfile
@@ -1,11 +1,10 @@
-# Description: The Control Center for MATE
+# Description: The Control Center for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: caja dconf desktop-file-utils gsettings-desktop-schemas gtk2 libgtop librsvg libunique1 libxss xorg-libxt mate-desktop mate-icon-theme mate-libkbd mate-menus marco mate-settings-daemon
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: murrine caja dconf desktop-file-utils gsettings-desktop-schemas gtk2 libgtop librsvg libunique1 xorg-libxscrnsaver xorg-libxt mate-desktop mate-icon-theme mate-libkbd mate-menus marco mate-settings-daemon
 
 name=mate-control-center
-version=1.14.0
+version=1.18.1
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -15,8 +14,6 @@ cd $name-$version
 --sysconfdir=/etc \
 --localstatedir=/var \
 --disable-static \
---disable-scrollkeeper \
---enable-aboutme \
 --disable-update-mimedb
 make
 make DESTDIR=$PKG install

--- a/mate/mate-control-center/mate-control-center.post-install
+++ b/mate/mate-control-center/mate-control-center.post-install
@@ -1,4 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    update-mime-database /usr/share/mime/ > /dev/null
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
-    update-desktop-database -q

--- a/mate/mate-desktop/Pkgfile
+++ b/mate/mate-desktop/Pkgfile
@@ -1,11 +1,11 @@
-# Description:Library with common API for various MATE modules
+# Description: Library with common API for various MATE modules.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: dconf gtk2 startup-notification
+# Run on: gobject-introspection gtk-doc intltool
 
 name=mate-desktop
-version=1.14.1
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/${name}-${version}.tar.xz)
 
@@ -13,12 +13,7 @@ build() {
 cd $name-$version
 ./configure \
         --prefix=/usr \
-        --with-gtk=2.0 \
-        --enable-mpaste \
-        --disable-static \
-        --disable-schemas-compile \
-        --disable-desktop-docs \
-        --enable-gtk-doc
+        --disable-schemas-compile 
 make
 make DESTDIR=$PKG install
 }

--- a/mate/mate-desktop/Pkgfile
+++ b/mate/mate-desktop/Pkgfile
@@ -1,8 +1,8 @@
 # Description: Library with common API for various MATE modules.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: dconf gtk2 startup-notification
-# Run on: gobject-introspection gtk-doc intltool
+# Depends on: dconf gtk3 startup-notification
+
 
 name=mate-desktop
 version=1.18.0

--- a/mate/mate-desktop/mate-desktop.post-install
+++ b/mate/mate-desktop/mate-desktop.post-install
@@ -1,1 +1,0 @@
-glib-compile-schemas usr/share/glib-2.0/schemas/

--- a/mate/mate-icon-theme/Pkgfile
+++ b/mate/mate-icon-theme/Pkgfile
@@ -4,7 +4,7 @@
 # Depends on: gtk-update-icon-cache icon-naming-utils intltool
 
 name=mate-icon-theme
-version=1.18.1
+version=1.18.2
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/${name}-$version.tar.xz)
 

--- a/mate/mate-icon-theme/Pkgfile
+++ b/mate/mate-icon-theme/Pkgfile
@@ -1,11 +1,10 @@
-# Description:  MATE icon theme
+# Description: MATE icon theme.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: gtk-update-icon-cache icon-naming-utils 
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: gtk-update-icon-cache icon-naming-utils intltool
 
 name=mate-icon-theme
-version=1.14.0
+version=1.18.1
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/${name}-$version.tar.xz)
 
@@ -14,5 +13,4 @@ cd $name-$version
 ./configure --prefix=/usr 
 make
 make DESTDIR=$PKG install
-rm -f  $PKG/usr/share/icons/mate/icon-theme.cache
 }

--- a/mate/mate-icon-theme/mate-icon-theme.post-install
+++ b/mate/mate-icon-theme/mate-icon-theme.post-install
@@ -1,2 +1,0 @@
-gtk-update-icon-cache -q -t -f /usr/share/icons/mate
-    gtk-update-icon-cache -q -t -f /usr/share/icons/menta

--- a/mate/mate-libkbd/Pkgfile
+++ b/mate/mate-libkbd/Pkgfile
@@ -1,20 +1,17 @@
-# Description: MATE keyboard library
+# Description: MATE keyboard library.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: mate-common dconf gtk2 iso-codes xorg-libxklavier
 
 name=mate-libkbd
-version=1.14.1
+version=1.18.1
 release=1
 _name=libmatekbd
 source=(http://pub.mate-desktop.org/releases/${version%.*}/${_name}-$version.tar.xz)
 
 build() {
 cd ${_name}-$version
-./configure  --prefix=/usr \
---with-gtk=2.0 \
---disable-static
+./configure  --prefix=/usr 
 make
 make DESTDIR=$PKG install
 }

--- a/mate/mate-libkbd/Pkgfile
+++ b/mate/mate-libkbd/Pkgfile
@@ -1,7 +1,7 @@
 # Description: MATE keyboard library.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: mate-common dconf gtk2 iso-codes xorg-libxklavier
+# Depends on: mate-common dconf gtk3 iso-codes xorg-libxklavier
 
 name=mate-libkbd
 version=1.18.1

--- a/mate/mate-libkbd/mate-libkbd.post-install
+++ b/mate/mate-libkbd/mate-libkbd.post-install
@@ -1,1 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/

--- a/mate/mate-libmixer/Pkgfile
+++ b/mate/mate-libmixer/Pkgfile
@@ -1,11 +1,10 @@
-# Description: Mixer library for MATE Desktop
+# Description: Mixer library for MATE Desktop.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: alsa-lib pulseaudio
 
 name=mate-libmixer
-version=1.14.0
+version=1.18.0
 release=1
 _name=libmatemixer
 source=(http://pub.mate-desktop.org/releases/${version%.*}/${_name}-$version.tar.xz)

--- a/mate/mate-libweather/Pkgfile
+++ b/mate/mate-libweather/Pkgfile
@@ -1,11 +1,10 @@
 # Description: Provides access to weather information from the Internet.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: dconf gtk2 libsoup 
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: dconf gtk2 libsoup
 
 name=mate-libweather
-version=1.14.0
+version=1.18.0
 release=1
 _name=libmateweather
 source=(http://pub.mate-desktop.org/releases/${version%.*}/${_name}-$version.tar.xz)

--- a/mate/mate-libweather/Pkgfile
+++ b/mate/mate-libweather/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Provides access to weather information from the Internet.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: dconf gtk2 libsoup
+# Depends on: dconf gtk3 libsoup
 
 name=mate-libweather
 version=1.18.0
@@ -15,7 +15,7 @@ cd ${_name}-$version
         --prefix=/usr \
         --sysconfdir=/etc \
         --localstatedir=/var \
-        --with-gtk=2.0 \
+        --with-gtk=3.0 \
         --disable-static \
         --disable-python \
         --enable-locations-compression

--- a/mate/mate-libweather/mate-libweather.post-install
+++ b/mate/mate-libweather/mate-libweather.post-install
@@ -1,1 +1,0 @@
-/usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas > /dev/null 2>&1

--- a/mate/mate-media/Pkgfile
+++ b/mate/mate-media/Pkgfile
@@ -1,11 +1,10 @@
-# Description: MATE Media Tools (GStreamer)
+# Description: MATE Media Tools (GStreamer).
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: gobject-introspection gtk2 libcanberra libunique1 libxml2 mate-desktop mate-libmixer marco
 
-
 name=mate-media
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -16,7 +15,6 @@ cd $name-$version
         --sysconfdir=/etc \
         --libexecdir=/usr/lib/${name} \
         --localstatedir=/var \
-        --with-gtk=2.0 \
         --disable-static
     make
 make 	

--- a/mate/mate-media/Pkgfile
+++ b/mate/mate-media/Pkgfile
@@ -1,7 +1,7 @@
 # Description: MATE Media Tools (GStreamer).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gobject-introspection gtk2 libcanberra libunique1 libxml2 mate-desktop mate-libmixer marco
+# Depends on: gobject-introspection gtk3 libcanberra libunique1 libxml2 mate-desktop mate-libmixer marco
 
 name=mate-media
 version=1.18.0

--- a/mate/mate-media/mate-media.post-install
+++ b/mate/mate-media/mate-media.post-install
@@ -1,2 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/mate

--- a/mate/mate-menus/Pkgfile
+++ b/mate/mate-menus/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Menu MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on:  intltool glib gobject-introspection python
+# Depends on:  intltool glib gobject-introspection python2
 
 name=mate-menus
 version=1.18.0

--- a/mate/mate-menus/Pkgfile
+++ b/mate/mate-menus/Pkgfile
@@ -1,11 +1,10 @@
-# Description: Menu MATE 
+# Description: Menu MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on:  intltool glib gobject-introspection python
 
 name=mate-menus
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -15,8 +14,7 @@ cd $name-$version
 --prefix=/usr \
 --sysconfdir=/etc \
 --localstatedir=/var  \
---enable-python \
---disable-static
+--enable-python 
 make
 make DESTDIR=$PKG install
 }

--- a/mate/mate-notification-daemon/Pkgfile
+++ b/mate/mate-notification-daemon/Pkgfile
@@ -1,19 +1,17 @@
-# Description: Notification daemon for MATE
+# Description: Notification daemon for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: dconf gtk2 libcanberra libwnck libnotify
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: dconf gtk2 libcanberra libwnck3 libnotify
 
 name=mate-notification-daemon
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
 build() {
 cd $name-$version
 ./configure  --prefix=/usr \
-        --libexecdir=/usr/lib/${name} \
-        --with-gtk=2.0 \
-        --disable-static
+        --libexecdir=/usr/lib/${name} 
 make
 make DESTDIR=$PKG install
 }

--- a/mate/mate-notification-daemon/Pkgfile
+++ b/mate/mate-notification-daemon/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Notification daemon for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: dconf gtk2 libcanberra libwnck3 libnotify
+# Depends on: dconf gtk3 libcanberra libwnck3 libnotify
 
 name=mate-notification-daemon
 version=1.18.0

--- a/mate/mate-notification-daemon/mate-notification-daemon.post-install
+++ b/mate/mate-notification-daemon/mate-notification-daemon.post-install
@@ -1,2 +1,0 @@
-glib-compile-schemas usr/share/glib-2.0/schemas/
-gtk-update-icon-cache -q -t -f usr/share/icons/hicolor

--- a/mate/mate-panel/Pkgfile
+++ b/mate/mate-panel/Pkgfile
@@ -1,10 +1,10 @@
-# Description: MATE panel
+# Description: MATE panel.
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: caja gobject-introspection gtk2 libcanberra xorg-libice librsvg libsoup xorg-libsm xorg-libxau libwnck marco mate-desktop mate-libweather mate-menus mate-session-manager
 
 name=mate-panel
-version=1.14.0
+version=1.18.1
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -14,7 +14,6 @@ cd $name-$version
         --libexecdir=/usr/lib/${name} \
         --sysconfdir=/etc \
         --localstatedir=/var \
-        --with-gtk=2.0 \
         --enable-introspection \
         --disable-static
 make

--- a/mate/mate-panel/Pkgfile
+++ b/mate/mate-panel/Pkgfile
@@ -1,7 +1,7 @@
 # Description: MATE panel.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: caja gobject-introspection gtk2 libcanberra xorg-libice librsvg libsoup xorg-libsm xorg-libxau libwnck marco mate-desktop mate-libweather mate-menus mate-session-manager
+# Depends on: caja gobject-introspection gtk2 libcanberra xorg-libice librsvg libsoup xorg-libsm xorg-libxau libwnck marco mate-desktop mate-libweather mate-menus mate-session-manager libwnck3
 
 name=mate-panel
 version=1.18.1

--- a/mate/mate-panel/Pkgfile
+++ b/mate/mate-panel/Pkgfile
@@ -1,7 +1,7 @@
 # Description: MATE panel.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: caja gobject-introspection gtk2 libcanberra xorg-libice librsvg libsoup xorg-libsm xorg-libxau libwnck marco mate-desktop mate-libweather mate-menus mate-session-manager libwnck3
+# Depends on: caja gobject-introspection gtk3 libcanberra xorg-libice librsvg libsoup xorg-libsm xorg-libxau libwnck marco mate-desktop mate-libweather mate-menus mate-session-manager libwnck3
 
 name=mate-panel
 version=1.18.1

--- a/mate/mate-panel/mate-panel.post-install
+++ b/mate/mate-panel/mate-panel.post-install
@@ -1,2 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor

--- a/mate/mate-polkit/Pkgfile
+++ b/mate/mate-polkit/Pkgfile
@@ -1,11 +1,10 @@
-# Description: PolicyKit integration for the MATE desktop
+# Description: PolicyKit integration for the MATE desktop.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: polkit gtk2
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: polkit gtk3
 
 name=mate-polkit
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -16,7 +15,6 @@ cd $name-$version
         --libexecdir=/usr/lib/${name} \
         --sysconfdir=/etc \
         --localstatedir=/var \
-        --with-gtk=2.0 \
         --enable-introspection \
         --disable-static
 make

--- a/mate/mate-power-manager/Pkgfile
+++ b/mate/mate-power-manager/Pkgfile
@@ -1,11 +1,10 @@
 # Description: Power management tool for the MATE desktop.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: dconf libgnome-keyring libcanberra libnotify libunique1 mate-desktop mate-panel upower gvfs
 
 name=mate-power-manager
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -18,8 +17,6 @@ cd $name-$version
         --localstatedir=/var \
         --sbindir=/usr/bin \
         --enable-applets \
-        --enable-unique \
-        --with-gtk=2.0 \
         --disable-strict
 make
 make DESTDIR=$PKG install

--- a/mate/mate-power-manager/mate-power-manager.post-install
+++ b/mate/mate-power-manager/mate-power-manager.post-install
@@ -1,2 +1,0 @@
-glib-compile-schemas usr/share/glib-2.0/schemas/
-gtk-update-icon-cache -q -t -f usr/share/icons/hicolor

--- a/mate/mate-screensaver/Pkgfile
+++ b/mate/mate-screensaver/Pkgfile
@@ -1,10 +1,10 @@
-# Description:  Screensaver for MATE
+# Description: Screensaver for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: gtk2 libnotify libxss mate-desktop mate-libkbd mate-menus mate-power-manager mate-session-manager 
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: gtk2 libnotify xorg-libxscrnsaver mate-desktop mate-libkbd mate-menus mate-power-manager mate-session-manager xorg-libxscrnsaver
+
 name=mate-screensaver
-version=1.14.1
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -18,9 +18,7 @@ cd $name-$version
         --with-xscreensaverhackdir=/usr/lib/xscreensaver \
         --with-mit-ext \
         --with-libnotify \
-        --enable-locking \
-        --with-gtk=2.0 \
-        --disable-static
+        --enable-locking 
 make 
 make DESTDIR=$PKG install
 }

--- a/mate/mate-screensaver/Pkgfile
+++ b/mate/mate-screensaver/Pkgfile
@@ -1,7 +1,7 @@
 # Description: Screensaver for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 libnotify xorg-libxscrnsaver mate-desktop mate-libkbd mate-menus mate-power-manager mate-session-manager xorg-libxscrnsaver
+# Depends on: gtk3 libnotify xorg-libxscrnsaver mate-desktop mate-libkbd mate-menus mate-power-manager mate-session-manager xorg-libxscrnsaver
 
 name=mate-screensaver
 version=1.18.0

--- a/mate/mate-screensaver/mate-screensaver.post-install
+++ b/mate/mate-screensaver/mate-screensaver.post-install
@@ -1,1 +1,0 @@
-glib-compile-schemas usr/share/glib-2.0/schemas/

--- a/mate/mate-session-manager/Pkgfile
+++ b/mate/mate-session-manager/Pkgfile
@@ -1,10 +1,10 @@
-# Description: The MATE Session Handler
+# Description: The MATE Session Handler.
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
-# Depends on: gtk2 mate-desktop mate-polkit mate-settings-daemon xorg-libsm xorg-libxtst 
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
+# Depends on: gtk2 mate-desktop mate-polkit mate-settings-daemon xorg-libsm xorg-libxtst
 
 name=mate-session-manager
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -14,7 +14,6 @@ cd $name-$version
         --libexecdir=/usr/lib/${name} \
         --sysconfdir=/etc \
         --localstatedir=/var \
-        --with-gtk=2.0 \
         --disable-upower
 make
 make DESTDIR=$PKG install

--- a/mate/mate-session-manager/Pkgfile
+++ b/mate/mate-session-manager/Pkgfile
@@ -1,7 +1,7 @@
 # Description: The MATE Session Handler.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: gtk2 mate-desktop mate-polkit mate-settings-daemon xorg-libsm xorg-libxtst
+# Depends on: gtk3 mate-desktop mate-polkit mate-settings-daemon xorg-libsm xorg-libxtst
 
 name=mate-session-manager
 version=1.18.0

--- a/mate/mate-session-manager/mate-session-manager.post-install
+++ b/mate/mate-session-manager/mate-session-manager.post-install
@@ -1,2 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor

--- a/mate/mate-settings-daemon/Pkgfile
+++ b/mate/mate-settings-daemon/Pkgfile
@@ -1,7 +1,7 @@
 # Description: The MATE Settings daemon (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: dconf gtk2 libcanberra libnotify mate-desktop mate-libkbd mate-libmixer nss xorg-libxt
+# Depends on: dconf gtk3 libcanberra libnotify mate-desktop mate-libkbd mate-libmixer nss xorg-libxt
 
 name=mate-settings-daemon
 version=1.18.1

--- a/mate/mate-settings-daemon/Pkgfile
+++ b/mate/mate-settings-daemon/Pkgfile
@@ -1,10 +1,10 @@
-# Description:  The MATE Settings daemon (GTK2 version)
+# Description: The MATE Settings daemon (GTK2 version).
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: dconf gtk2 libcanberra libnotify mate-desktop mate-libkbd mate-libmixer nss xorg-libxt
 
 name=mate-settings-daemon
-version=1.14.0
+version=1.18.1
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -14,8 +14,8 @@ cd $name-$version
         --prefix=/usr \
         --libexecdir=/usr/lib/${name} \
         --sysconfdir=/etc \
-        --localstatedir=/var \
-        --with-gtk=2.0
+        --enable-polkit \
+        --enable-pulse
 make
 make DESTDIR=$PKG install
 }

--- a/mate/mate-settings-daemon/mate-settings-daemon.post-install
+++ b/mate/mate-settings-daemon/mate-settings-daemon.post-install
@@ -1,2 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor

--- a/mate/mate-system-monitor/Pkgfile
+++ b/mate/mate-system-monitor/Pkgfile
@@ -1,10 +1,10 @@
-# Description: A system monitor for MATE
+# Description: A system monitor for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
-# Packager: fanchyannmaria at orange dot fr
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: dconf gtk2 gtkmm3 glibmm libgtop libwnck3 librsvg mate-icon-theme
 
 name=mate-system-monitor
-version=1.14.0
+version=1.18.0
 release=1
 source=(http://pub.mate-desktop.org/releases/${version%.*}/$name-$version.tar.xz)
 
@@ -13,9 +13,7 @@ cd $name-$version
 ./configure \
         --prefix=/usr \
         --libexecdir=/usr/lib/${name} \
-        --localstatedir=/var \
-        --with-gtk=2.0 \
-        --disable-static
+        --localstatedir=/var 
 make
 make DESTDIR=$PKG install
 }

--- a/mate/mate-system-monitor/Pkgfile
+++ b/mate/mate-system-monitor/Pkgfile
@@ -1,7 +1,7 @@
 # Description: A system monitor for MATE.
 # URL: http://matsusoft.com.ar/projects/mate
 # Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
-# Depends on: dconf gtk2 gtkmm3 glibmm libgtop libwnck3 librsvg mate-icon-theme
+# Depends on: dconf gtk3 gtkmm3 glibmm libgtop libwnck3 librsvg mate-icon-theme
 
 name=mate-system-monitor
 version=1.18.0

--- a/mate/mate-system-monitor/mate-system-monitor.post-install
+++ b/mate/mate-system-monitor/mate-system-monitor.post-install
@@ -1,1 +1,0 @@
-glib-compile-schemas /usr/share/glib-2.0/schemas/

--- a/mate/mate-themes/Pkgfile
+++ b/mate/mate-themes/Pkgfile
@@ -1,12 +1,11 @@
-# Description: Themes MATE
+# Description: Default themes for MATE desktop
 # URL: http://matsusoft.com.ar/projects/mate
-# Maintainer: NuTyX core team
-# Packager: nutyx
+# Packager: fanchyannmaria at orange dot fr, tnut at nutyx dot org
 # Depends on: gtk2
 
 
 name=mate-themes
-version=3.20.7
+version=3.22.8
 release=1
 source=(http://pub.mate-desktop.org/releases/themes/${version%.*}/${name}-${version}.tar.xz)
 

--- a/mate/mate-themes/mate-themes.post-install
+++ b/mate/mate-themes/mate-themes.post-install
@@ -1,3 +1,0 @@
-gtk-update-icon-cache -q -t -f usr/share/icons/ContrastHigh
-gtk-update-icon-cache -q -t -f usr/share/icons/mate
-


### PR DESCRIPTION
Mise à jour de mate 1.6 vers mate 1.8. 
La mise à jour et la compilation n'ont posé aucun problème. Il a fallu ajouter ou mettre à jour quelques "libraries" et déplacer libpeas de gnome vers gui.
Dans l'attente de remarques et de validations de la nutyx team, merci et bon courage
