### PR TITLE
Necessite la version gtk3 de libindicator

### DIFF
--- a/mate-extra/mate-indicator-applet/Pkgfile
+++ b/mate-extra/mate-indicator-applet/Pkgfile
@@ -1,4 +1,4 @@
-# Depends on: gtk3 libindicator-gtk2 mate-panel
+# Depends on: gtk3 libindicator-gtk3 mate-panel
 
 description="Applet MATE"
 url="http://matsusoft.com.ar/projects/mate"


### PR DESCRIPTION
Pour construire le paquet il faut libincidator-gtk3