### PR TITLE
Dépends de gtksourceview3

### DIFF
--- a/mate-extra/mate-applets/Pkgfile
+++ b/mate-extra/mate-applets/Pkgfile
@@ -1,4 +1,4 @@
-# Depends on: gtksourceview2 libgtop libnotify mate-panel mate-icon-theme python-gobject upower wireless-tools upower
+# Depends on: gtksourceview3 libgtop libnotify mate-panel mate-icon-theme python-gobject upower wireless-tools upower
 description="Applets for MATE panel"
 url="http://matsusoft.com.ar/projects/mate"
 packager="fanchyannmaria at orange dot fr, tnut at nutyx dot org"


### PR DESCRIPTION
Paquet dépends de gtksourceview3 et non gtkviewsource2 pour compilation de Stickynotes